### PR TITLE
fix:correctly query magic link by user ID

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -1,7 +1,6 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { PassportModule } from '@nestjs/passport';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
 import { UserModule } from '@modules/user/user.module';
 import { TypeOrmModule } from '@nestjs/typeorm';

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -158,7 +158,7 @@ export class AuthService {
       }
       const magicLink = await this.magicLinkRepository.findOne({
         where: {
-          user: user,
+          user: { id: user.id },
           token,
         },
       });

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -24,13 +24,6 @@ export class UserService {
     return this.usersRepository.save(user);
   }
 
-  async create(data: { email: string }): Promise<User> {
-    const newUser = this.usersRepository.create({
-      email: data.email,
-    });
-
-    return this.usersRepository.save(newUser);
-  }
   async getMe(userId: string): Promise<User> {
     const user = await this.usersRepository.findOne({
       where: {


### PR DESCRIPTION
Fixes a bug in verifyToken that caused all magic link verifications to fail.

The magicLinkRepository query is updated to search by user.id instead of passing the entire user object, which caused the TypeORM query to fail.

Removed duplicate imports.

**Checklist:**
[x] Verify successful login with a new link.

[x] Verify that login fails with an old (already used) link.