### PR TITLE
feat: added protection for ocr and blood test api's

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.1.6",
         "@types/compression": "^1.8.1",
-        "@types/cookie-parser": "^1.4.9",
+        "@types/cookie-parser": "^1.4.10",
         "@types/express": "^5.0.0",
         "@types/express-session": "^1.18.2",
         "@types/jest": "^30.0.0",
@@ -4628,9 +4628,9 @@
       }
     },
     "node_modules/@types/cookie-parser": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
-      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.1.6",
     "@types/compression": "^1.8.1",
-    "@types/cookie-parser": "^1.4.9",
+    "@types/cookie-parser": "^1.4.10",
     "@types/express": "^5.0.0",
     "@types/express-session": "^1.18.2",
     "@types/jest": "^30.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService, ConfigType } from '@nestjs/config';
 import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
+import { JwtModule } from '@nestjs/jwt';
 import { AuthModule } from '@modules/auth/auth.module';
 import { UserModule } from '@modules/user/user.module';
 import { databaseConfig } from '@config/database.config';
@@ -17,6 +18,7 @@ import { BloodTestModule } from '@modules/BloodTest/bloodTest.module';
 type AppConfig = {
   database: ConfigType<typeof databaseConfig>;
 };
+
 @Module({
   imports: [
     ThrottlerModule.forRoot([
@@ -37,7 +39,17 @@ type AppConfig = {
       ],
       validate,
     }),
-
+    JwtModule.registerAsync({
+      global: true,
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: {
+          expiresIn: '24h',
+        },
+      }),
+      inject: [ConfigService],
+    }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -47,7 +59,6 @@ type AppConfig = {
         return dbConfig;
       },
     }),
-
     UserModule,
     AuthModule,
     OcrModule,

--- a/src/modules/BloodTest/bloodTest.controller.ts
+++ b/src/modules/BloodTest/bloodTest.controller.ts
@@ -1,14 +1,16 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { BloodTestService } from './bloodTest.service';
 import type {
   BloodTestData,
   BloodTestValidation,
 } from '@common/interfaces/blood-test-data.interface';
+import { AuthGuard } from '@modules/auth/guards/auth.guard';
 
 @Controller('')
 export class BloodTestController {
   constructor(private bloodTestService: BloodTestService) {}
 
+  @UseGuards(AuthGuard)
   @Post('validate-blood-test')
   isValid(@Body() data: BloodTestData): Promise<BloodTestValidation> {
     return this.bloodTestService.validateBloodTest(data);

--- a/src/modules/BloodTest/bloodTest.service.ts
+++ b/src/modules/BloodTest/bloodTest.service.ts
@@ -23,7 +23,7 @@ export function cleanJsonString(str: string): string {
 @Injectable()
 export class BloodTestService {
   private readonly MAX_TOKENS = 4000;
-  private readonly MODEL = 'gpt-4-turbo-preview';
+  private readonly MODEL = 'gpt-4o-mini';
 
   constructor(private readonly openAI: OpenAI) {}
 

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -11,6 +11,7 @@ import {
   UseGuards,
   Logger,
 } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { ApiOperation, ApiQuery, ApiResponse } from '@nestjs/swagger';
 import type { Response } from 'express';
@@ -36,6 +37,7 @@ export class AuthController {
   constructor(
     private authService: AuthService,
     private configService: ConfigService,
+    private jwtService: JwtService,
   ) {}
 
   @UseGuards(GoogleAuthGuard)
@@ -74,11 +76,19 @@ export class AuthController {
         req.user,
         'google',
       );
+
       const url = this.configService.get<string>('FRONTEND_URL');
 
       if (!url) throw new Error('FRONTEND_URL is not defined');
 
-      res.cookie('jwt', response.accessToken, {
+      const accessToken =
+        response.accessToken ||
+        this.jwtService.sign({
+          email: req.user.email,
+          sub: req.user.id,
+        });
+
+      res.cookie('auth-token', accessToken, {
         httpOnly: true,
         secure: false,
         sameSite: 'lax',
@@ -146,8 +156,9 @@ export class AuthController {
   async verifyToken(
     @Query('token') token: string,
     @Query('email') email: string,
+    @Res({ passthrough: true }) response: Response,
   ): Promise<MagicLinkResponseDto> {
-    return this.authService.verifyToken(token, email);
+    return this.authService.verifyToken(token, email, response);
   }
   @UseGuards(LinkedInAuthGuard)
   @Get('linkedin/login')
@@ -192,7 +203,7 @@ export class AuthController {
 
       if (!url) throw new Error('FRONTEND_URL is not defined');
 
-      res.cookie('jwt', response.accessToken, {
+      res.cookie('auth-token', response.accessToken, {
         httpOnly: true,
         secure: false,
         sameSite: 'lax',
@@ -248,7 +259,7 @@ export class AuthController {
 
       if (!url) throw new Error('FRONTEND_URL is not defined');
 
-      res.cookie('jwt', response.accessToken, {
+      res.cookie('auth-token', response.accessToken, {
         httpOnly: true,
         secure: false,
         sameSite: 'lax',

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -10,16 +10,17 @@ import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as crypto from 'crypto';
+import { Response } from 'express';
 import * as nodemailer from 'nodemailer';
 import SMTPTransport from 'nodemailer/lib/smtp-transport';
 import { OAuthUserDto } from '@database/dtos/oauth-user.dto';
 import { FacebookUserDto } from '@database/dtos/facebook-user.dto';
+import { COOKIE_MAX_AGE } from '@common/constants';
 import { UserService } from '@modules/user/user.service';
 import { CreateUserDto } from './dto/create-user-dto';
 import { AuthResponseDto } from './dto/auth-response.dto';
 import { MagicLink } from './entities/magic-link.entity';
 import { emailTemplate } from 'utils/emailTemplates/magicLink';
-
 @Injectable()
 export class AuthService {
   private transporter: nodemailer.Transporter;
@@ -109,7 +110,9 @@ export class AuthService {
     }
   }
 
-  async sendMagicLink(email: string): Promise<{ message: string }> {
+  async sendMagicLink(
+    email: string,
+  ): Promise<{ message: string; token: string }> {
     try {
       let user = await this.usersService.findByEmail(email);
 
@@ -138,7 +141,7 @@ export class AuthService {
         html: emailTemplate(magicLinkUrl),
       });
 
-      return { message: `Sign-in link sent to ${email}` };
+      return { message: `Sign-in link sent to ${email}`, token: token };
     } catch (error) {
       if (error instanceof Error) {
         throw new BadRequestException(`Failed to send email: ${error.message}`);
@@ -150,6 +153,7 @@ export class AuthService {
   async verifyToken(
     token: string,
     email: string,
+    response: Response,
   ): Promise<{ accessToken: string; email: string }> {
     try {
       const user = await this.usersService.findByEmail(email);
@@ -177,6 +181,13 @@ export class AuthService {
 
       const payload = { email: user.email, sub: user.id };
       const accessToken = this.jwtService.sign(payload);
+
+      response.cookie('auth-token', accessToken, {
+        httpOnly: true,
+        secure: false,
+        sameSite: 'lax',
+        maxAge: COOKIE_MAX_AGE,
+      });
 
       return { accessToken, email };
     } catch (error) {

--- a/src/modules/auth/guards/auth.guard.ts
+++ b/src/modules/auth/guards/auth.guard.ts
@@ -1,0 +1,56 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { Request } from 'express';
+
+interface JwtPayload {
+  email: string;
+  sub: string;
+  iat?: number;
+  exp?: number;
+}
+
+interface RequestWithUser extends Request {
+  user?: JwtPayload;
+  cookies: {
+    'auth-token'?: string;
+    [key: string]: string | undefined;
+  };
+}
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(
+    private jwtService: JwtService,
+    private configService: ConfigService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<RequestWithUser>();
+    const token = this.extractToken(request);
+
+    if (!token) {
+      throw new UnauthorizedException('No authentication token found');
+    }
+
+    try {
+      const payload = await this.jwtService.verifyAsync<JwtPayload>(token, {
+        secret: this.configService.get<string>('JWT_SECRET'),
+      });
+      request.user = payload;
+    } catch {
+      throw new UnauthorizedException('Invalid or expired token');
+    }
+
+    return true;
+  }
+
+  private extractToken(request: RequestWithUser): string | undefined {
+    return request.cookies['auth-token'];
+  }
+}

--- a/src/modules/ocr/ocr.controller.ts
+++ b/src/modules/ocr/ocr.controller.ts
@@ -1,14 +1,15 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { BloodTestData } from '@common/interfaces/blood-test-data.interface';
+import { AuthGuard } from '@modules/auth/guards/auth.guard';
 import { CreateOcrDto } from './dto/create.dto';
 import { OcrService } from './orc.service';
-
 @ApiTags('Ocr')
 @Controller('ocr')
 export class OcrController {
   constructor(private ocrService: OcrService) {}
 
+  @UseGuards(AuthGuard)
   @ApiOperation({ summary: 'Extraction text from image' })
   @ApiResponse({
     status: 201,


### PR DESCRIPTION


- Created `AuthGuard` to validate JWT tokens from httpOnly cookies
- Protected endpoints with `@UseGuards(AuthGuard)`:
  - `/ocr/extract`
  - `/validate-blood-test`
- OAuth callbacks (Google/LinkedIn/Facebook) now set JWT in `auth-token` cookie
- Magic link verification sets JWT in `auth-token` cookie upon successful validation


## Checklist 

- [ ] Assigned myself to the PR
- [ ] Assigned the appropriate labels to the PR
- [ ] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [ ] Performed a self-review of my code
- [ ] Types for input and output parameters
- [ ] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [ ] Don't have magic numbers
- [ ] Compare only with constants not with strings
- [ ] No ternary operator inside the ternary operator
- [ ] Don't have commented code
- [ ] No links in the code (env links in .env file, constant links in constant file)
- [ ] Used camelCase for variables and functions
- [ ] Date and time formats are in the constants
- [ ] Functions are public only if used outside the class
- [ ] No hardcoded values
- [ ] Code covered by tests
- [ ] Swagger documentation updated for each endpoint (2xx, 4xx, 5xx responses)
- [ ] Database requests are optimized and not redundant
- [ ] Unit tests written
- [ ] Use ConfigService instead of process.env
- [ ] Use transactions if there is a call chain that mutates data in different tables
- [ ] Use @Index decorator for frequently requested data
- [ ] REST API Naming Convention followed for endpoints
- [ ] UUIDs used for primary keys