### PR TITLE
feat: add getMe and logout

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -26,6 +26,7 @@ import { GoogleAuthGuard } from './guards/google-auth.guard';
 import { LinkedInAuthGuard } from './guards/linkedin-auth.guard';
 import { COOKIE_MAX_AGE } from '@common/constants';
 import { FacebookAuthGuard } from './guards/facebook-auth.guard';
+import { AuthGuard } from './guards/auth.guard';
 
 interface RequestWithUser extends Request {
   user: OAuthUserDto;
@@ -39,6 +40,25 @@ export class AuthController {
     private configService: ConfigService,
     private jwtService: JwtService,
   ) {}
+
+  @UseGuards(AuthGuard)
+  @Get('me')
+  @ApiOperation({ summary: "Get the current user's profile" })
+  getProfile(@Req() req: RequestWithUser) {
+    return req.user;
+  }
+
+  @Post('logout')
+  @HttpCode(HttpStatus.OK)
+  logout(@Res({ passthrough: true }) res: Response) {
+    res.cookie('auth-token', '', {
+      httpOnly: true,
+      secure: false,
+      sameSite: 'lax',
+      expires: new Date(0),
+    });
+    return { message: 'Logged out' };
+  }
 
   @UseGuards(GoogleAuthGuard)
   @Get('google/login')
@@ -96,7 +116,7 @@ export class AuthController {
       });
 
       this.logger.log('Google authentication successful, redirecting');
-      res.redirect(url);
+      res.redirect(`${url}/upload`);
     } catch (error) {
       this.logger.error('Google callback error:', error);
       const url = this.configService.get<string>('FRONTEND_URL');
@@ -211,7 +231,7 @@ export class AuthController {
       });
 
       this.logger.log('LinkedIn authentication successful, redirecting');
-      res.redirect(url);
+      res.redirect(`${url}/upload`);
     } catch (error) {
       this.logger.error('LinkedIn callback error:', error);
       const url = this.configService.get<string>('FRONTEND_URL');
@@ -267,7 +287,7 @@ export class AuthController {
       });
 
       this.logger.log('Facebook authentication successful, redirecting');
-      res.redirect(url);
+      res.redirect(`${url}/upload`);
     } catch (error) {
       this.logger.error('Facebook callback error:', error);
       const url = this.configService.get<string>('FRONTEND_URL');


### PR DESCRIPTION
[JIRA Ticket](https://trulyproject.atlassian.net/jira/core/projects/ALRAOT/list/?jql=project%20%3D%20%22ALRAOT%22%20ORDER%20BY%20created%20DESC&selectedIssue=ALRAOT-28)

### The main focus of this PR is the implementation of key backend endpoints to support the new frontend authentication flow (fetching the user, logging out, and handling post-login redirects).

**Key Changes**

GET /me Endpoint, POST /logout Endpoint

Post-Login Redirection:
res.redirect: Added a server-side redirect to the magic link verification flow.

User Flow: After a user successfully clicks their magic link, the backend sets the auth cookie and immediately forwards them to the /upload page.

Checklist:

- [x] getMe: Verify that after logging in, refreshing the /upload page keeps you on the page (and doesn't redirect to /login).

- [x] logout: Verify that clicking the "Log out" button successfully clears the auth-token cookie and redirects to /login.

- [x] Redirect: Verify that clicking a new magic link automatically logs you in and lands you directly on the /upload page.